### PR TITLE
[minor]Trim indent in search-tweets.rb

### DIFF
--- a/lib/search-tweets.rb
+++ b/lib/search-tweets.rb
@@ -199,7 +199,7 @@ class SearchTweets
 	Defaults:
 	     @interval = "hour"   #Set in constructor.
 	     @max_results = API_ACTIVITY_LIMIT   #Set in constructor.
-  '''
+    '''
 	
 	def build_request(rule, from_date=nil, to_date=nil)
 		request = {}


### PR DESCRIPTION
I trimmed indent in search-tweets.rb.

It is a subtle change however to make it a little bit easier to read it.